### PR TITLE
Fix String successive to support empty string case by returning itself.

### DIFF
--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -1435,7 +1435,7 @@ public:
      */
     String successive() const {
         auto result = String { *this };
-        assert(m_length > 0);
+        if (m_length == 0) return result;
         size_t index = size() - 1;
         char last_char = m_str[index];
         if (last_char == 'z') {


### PR DESCRIPTION
Hi @seven1m , I'm assuming here that the String successive method eventually wants to be compatible with Ruby's `String#succ`, and this update fixes the case where the input is an empty-string by returning an empty String rather than asserting.

I was unclear how the C++ functions were being tested, so as of now no tests were added for this update.