### PR TITLE
Optimize TM::String::prepend

### DIFF
--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -679,10 +679,10 @@ public:
         if (!str) return;
         const size_t new_length = strlen(str);
         if (new_length == 0) return;
-        char buf[m_length + 1];
-        memcpy(buf, c_str(), sizeof(char) * (m_length + 1));
-        set_str(str);
-        append(buf);
+        grow_at_least(new_length + m_length);
+        memmove(m_str + new_length, m_str, sizeof(char) * (new_length + 1));
+        memcpy(m_str, str, sizeof(char) * new_length);
+        m_length += new_length;
     }
 
     /**
@@ -698,10 +698,10 @@ public:
     void prepend(const String &str) {
         const size_t new_length = str.size();
         if (new_length == 0) return;
-        char buf[new_length + m_length + 1];
-        memcpy(buf, str.c_str(), sizeof(char) * new_length);
-        memcpy(buf + new_length, c_str(), sizeof(char) * (m_length + 1));
-        set_str(buf);
+        grow_at_least(new_length + m_length);
+        memmove(m_str + new_length, m_str, sizeof(char) * (m_length + 1));
+        memcpy(m_str, str.c_str(), sizeof(char) * new_length);
+        m_length += new_length;
     }
 
     /**

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -643,7 +643,7 @@ public:
      * ```
      */
     void prepend_char(char c) {
-        size_t total_length = m_length + 1;
+        const size_t total_length = m_length + 1;
         grow_at_least(total_length);
         memmove(m_str + 1, m_str, m_length + 1); // 1 extra for null terminator
         m_str[0] = c;
@@ -660,7 +660,7 @@ public:
      * ```
      */
     void prepend(long long i) {
-        int length = snprintf(NULL, 0, "%lli", i);
+        const int length = snprintf(NULL, 0, "%lli", i);
         char buf[length + 1];
         snprintf(buf, length + 1, "%lli", i);
         prepend(buf);
@@ -677,7 +677,7 @@ public:
      */
     void prepend(const char *str) {
         if (!str) return;
-        size_t new_length = strlen(str);
+        const size_t new_length = strlen(str);
         if (new_length == 0) return;
         char buf[m_length + 1];
         memcpy(buf, c_str(), sizeof(char) * (m_length + 1));
@@ -696,7 +696,7 @@ public:
      * ```
      */
     void prepend(const String &str) {
-        size_t new_length = str.size();
+        const size_t new_length = str.size();
         if (new_length == 0) return;
         char buf[new_length + m_length + 1];
         memcpy(buf, str.c_str(), sizeof(char) * new_length);


### PR DESCRIPTION
The old code created a temporary buffer on the stack, copied the data from m_str to the buffer, and copied the buffer back to m_str (which might have been relocated at that point). The change gets rid of the temporary buffer, which removes one of the memcpy operations.
    
As a fortunate side effect: this fixes a bug in case on of the TM::String objects had a nullbyte embedded. The old code did use `set_str(char*)`, which uses `strlen` to determine the length of the argument.
    
`prepend("\0")` will still fail, you would either have to wrap the input char* in a TM::String object with a length, or add an overload for `TM::String::prepend(char*, size_t)` to pass the length as an argument.
