### PR TITLE
Add move constructor for Hashmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV CC=$CC
 ARG CXX=g++
 ENV CXX=$CXX
 
-ENV LLVM_CONFIG=/usr/lib/llvm-11/bin/llvm-config
+ENV LLVM_CONFIG=/usr/lib/llvm-14/bin/llvm-config
 
 COPY Rakefile Rakefile
 COPY include include

--- a/include/tm/hashmap.hpp
+++ b/include/tm/hashmap.hpp
@@ -313,6 +313,28 @@ public:
     }
 
     /**
+     * Creates a new Hashmap from another Hashmap, and clear the input
+     *
+     * ```
+     * auto map1 = Hashmap<String, Thing>(HashType::TMString);
+     * map1.put("foo", Thing(1));
+     * auto map2 = Hashmap<String, Thing>(std::move(map1));
+     * assert_eq(Thing(1), map2.get("foo"));
+     * assert(map1.is_empty());
+     * ```
+     */
+    Hashmap(Hashmap &&other) {
+        m_size = other.m_size;
+        m_capacity = other.m_capacity;
+        m_map = other.m_map;
+        m_hash_fn = other.m_hash_fn;
+        m_compare_fn = other.m_compare_fn;
+        other.m_size = 0;
+        other.m_capacity = 0;
+        other.m_map = nullptr;
+    }
+
+    /**
      * Overwrites this Hashmap with another.
      *
      * ```


### PR DESCRIPTION
I was missing this one in https://github.com/natalie-lang/natalie/pull/1140 (although that one has been rewritten now, and should use RVO instead of move)