### PR TITLE
Add StringView support for char pointers, without the need to construct a String

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV CC=$CC
 ARG CXX=g++
 ENV CXX=$CXX
 
-ENV LLVM_CONFIG=/usr/lib/llvm-11/bin/llvm-config
+ENV LLVM_CONFIG=/usr/lib/llvm-14/bin/llvm-config
 
 COPY Rakefile Rakefile
 COPY include include

--- a/include/tm/string_view.hpp
+++ b/include/tm/string_view.hpp
@@ -28,7 +28,7 @@ public:
      * ```
      */
     explicit StringView(const String *string)
-        : m_string { string }
+        : m_string { string->c_str() }
         , m_length { string->length() } { }
 
     /**
@@ -53,7 +53,7 @@ public:
      * ```
      */
     explicit StringView(const String *string, size_t offset)
-        : m_string { string }
+        : m_string { string->c_str() }
         , m_offset { offset }
         , m_length { string->length() - offset } {
         assert(offset <= string->length());
@@ -77,7 +77,7 @@ public:
      * ```
      */
     explicit StringView(const String *string, size_t offset, size_t length)
-        : m_string { string }
+        : m_string { string->c_str() }
         , m_offset { offset }
         , m_length { length } {
         assert(offset <= string->length());
@@ -173,7 +173,7 @@ public:
             return false;
         if (m_length != other_length)
             return false;
-        return memcmp(m_string->c_str() + m_offset, other, sizeof(char) * m_length) == 0;
+        return memcmp(m_string + m_offset, other, sizeof(char) * m_length) == 0;
     }
 
     bool operator!=(const char *other) const {
@@ -205,7 +205,7 @@ public:
             return false;
         if (m_length != other.m_length)
             return false;
-        return memcmp(m_string->c_str() + m_offset, other.m_string->c_str(), sizeof(char) * m_length) == 0;
+        return memcmp(m_string + m_offset, other.m_string, sizeof(char) * m_length) == 0;
     }
 
     bool operator!=(const StringView &other) const {
@@ -243,7 +243,7 @@ public:
     String to_string() const {
         if (!m_string)
             return String();
-        return String { m_string->c_str() + m_offset, m_length };
+        return String { m_string + m_offset, m_length };
     }
 
     /**
@@ -277,7 +277,8 @@ public:
      */
     char at(size_t index) const {
         assert(m_string);
-        return m_string->at(m_offset + index);
+        assert(index < m_length);
+        return m_string[m_offset + index];
     }
 
     /**
@@ -294,7 +295,7 @@ public:
      */
     char operator[](size_t index) const {
         assert(m_string);
-        return (*m_string)[m_offset + index];
+        return m_string[m_offset + index];
     }
 
     /**
@@ -312,7 +313,7 @@ public:
      */
     const char *dangerous_pointer_to_underlying_data() const {
         assert(m_string);
-        return (*m_string).c_str() + m_offset;
+        return m_string + m_offset;
     }
 
     /**
@@ -329,7 +330,7 @@ public:
     bool is_empty() const { return m_length == 0; }
 
 private:
-    const String *m_string { nullptr };
+    const char *m_string { nullptr };
     size_t m_offset { 0 };
     size_t m_length { 0 };
 };

--- a/include/tm/string_view.hpp
+++ b/include/tm/string_view.hpp
@@ -45,6 +45,20 @@ public:
         , m_length { string.length() } { }
 
     /**
+     * Constructs a basic StringView from a character pointer,
+     * uses strlen(3) to determine the length.
+     *
+     * ```
+     * const char *str = "foo";
+     * auto view = StringView(str);
+     * assert_eq(3, view.size());
+     * ```
+     */
+    explicit StringView(const char *string)
+        : m_string { string }
+        , m_length { strlen(string) } { }
+
+    /**
      * Constructs a StringView with given offset.
      *
      * ```
@@ -101,6 +115,35 @@ public:
     }
 
     /**
+     * Constructs a StringView with given offset from a character pointer,
+     * uses strlen(3) to determine the length.
+     *
+     * ```
+     * const char *str = "foobar";
+     * auto view = StringView(str, 3);
+     * assert_str_eq("bar", view);
+     *
+     * const char *str2 = "foo";
+     * auto view2 = StringView(str2, 3);
+     * assert_str_eq("", view2);
+     * ```
+     *
+     * This constructor aborts if the offset is past the end of the String.
+     *
+     * ```should_abort
+     * const char *str = "foo";
+     * auto view = StringView(str, 4);
+     * (void)view;
+     * ```
+     */
+    explicit StringView(const char *string, size_t offset)
+        : m_string { string }
+        , m_offset { offset }
+        , m_length { strlen(string) - offset } {
+        assert(offset <= strlen(string));
+    }
+
+    /**
      * Constructs a StringView with given offset and length.
      *
      * ```
@@ -149,6 +192,28 @@ public:
         assert(offset <= string.length());
         assert(length <= string.length() - offset);
     }
+
+    /**
+     * Constructs a StringView with given offset and length from a character pointer.
+     *
+     * ```
+     * const char *str = "foo-bar-baz";
+     * auto view = StringView(str, 4, 3);
+     * assert_str_eq("bar", view);
+     * ```
+     *
+     * This constructor does not check the lengths of the input string.
+     *
+     * ```
+     * const char *str = "foobar";
+     * auto view = StringView(str, 3, 4);
+     * (void)view;
+     * ```
+     */
+    explicit StringView(const char *string, size_t offset, size_t length)
+        : m_string { string }
+        , m_offset { offset }
+        , m_length { length } { }
 
     /**
      * Constructs a StringView by copying an existing StringView.


### PR DESCRIPTION
This is the functionality I was missing in https://github.com/natalie-lang/natalie/pull/1116, that change has the following line:
```c++
names->insert(group[i] - 1, TM::String(reinterpret_cast<const char *>(name), len));
```
Here we have a `const char*` (or rather: the Onigmo equivalent of a character pointer), and create a String object just to be able to save it. This change allows us to make a simple view instead of a string, so we don't need to copy/duplicate the source.

There is a small backwards incompatibility in this code:
```c++
TM::String foo("foo");
TM::StringView foo_view(&foo); // This saves the result of foo->c_str() into foo_view
foo.append("this is a long string that might trigger reallocation");
assert(foo_view.c_str() == foo.c_str()); // This might fail, and make the view invalid
```
But the old code had some issues with mutating strings as well: one may shorten the string without updating the length saved in the view for example. I think as a general rule one should not mutate a string while there are views to the string in scope.