### PR TITLE
Mark String as final, make destructor non-virtual

### DIFF
--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -10,7 +10,7 @@
 
 namespace TM {
 
-class String {
+class String final {
 public:
     static constexpr int STRING_GROW_FACTOR = 2;
 
@@ -299,7 +299,7 @@ public:
         return str;
     }
 
-    virtual ~String() {
+    ~String() {
         delete[] m_str;
     }
 


### PR DESCRIPTION
The String is one of the primitives where subclassing is generally a pretty bad idea. The only use case I could think of is support for UTF16/UTF32/Any other encoding with characters of more than 8 bits, but that would be incompatible with this String class (and would be better done via a template to define the character size, similar to what the stdlib does).
With this class marked as final, there is no more need for the destructor to be virtual, which removes the vtable from the String instances. This means the String instances should be smaller (8 bytes less on 64 bits machines), and String destruction should be faster (because there is no more vtable lookup).