### PR TITLE
Add TM::Vector::concat

### DIFF
--- a/include/tm/vector.hpp
+++ b/include/tm/vector.hpp
@@ -351,6 +351,43 @@ public:
     }
 
     /**
+     * Concatenates (appends) a vector at the end
+     *
+     * ```
+     * auto vec = Vector<Thing> { Thing(1), Thing(2) };
+     * auto other_vec = Vector<Thing> { Thing(3), Thing(4) };
+     * vec.concat(other_vec);
+     * assert_eq(4, vec.size());
+     * assert_eq(1, vec[0].value());
+     * assert_eq(2, vec[1].value());
+     * assert_eq(3, vec[2].value());
+     * assert_eq(4, vec[3].value());
+     * ```
+     *
+     * It uses memcpy in case the value is trivially copyable
+     * ```
+     * auto vec = Vector<int> { 1, 2 };
+     * auto other_vec = Vector<int> { 3, 4 };
+     * vec.concat(other_vec);
+     * assert_eq(4, vec.size());
+     * assert_eq(1, vec[0]);
+     * assert_eq(2, vec[1]);
+     * assert_eq(3, vec[2]);
+     * assert_eq(4, vec[3]);
+     * ```
+     */
+    void concat(const Vector<T> &other) {
+        grow_at_least(m_size + other.size());
+        if constexpr (std::is_trivially_copyable<T>::value) {
+            memcpy(m_data + m_size, other.m_data, other.m_size * sizeof(T));
+            m_size += other.m_size;
+        } else {
+            for (auto &v : other)
+                push(v);
+        }
+    }
+
+    /**
      * Pushes (inserts) a value at the front (index 0).
      *
      * ```


### PR DESCRIPTION
This is based on Ruby's Array#concat. This has a few advantages:
* The call site can easily call `vector.append(other)`, instead of having to loop over the other vector and push every item separately.
* It resizes the target vector only once. If the other vector is more than twice the capacity of the target vector, this will reduce reallocs.
* It tries to use memcpy if the type is trivially copyable. It turns out the Natalie::Value object is.

I tried this in Natalie with ArrayObject::add changed:
```diff
     ArrayObject *new_array = new ArrayObject { *this };
-    new_array->concat(*other_array);
+    new_array->m_vector.concat(other_array->m_vector);
     return new_array;
```

With the test script:
```ruby
GC.disable

a1 = []
a2 = (201..400).to_a

p (a1 + a2).size
```
This is a pretty extreme case. The empty vector has a capacity of 10, every resize doubles it. The old code needed 5 resizes to get to a capacity of `10 * 2**5`, the new code simply resizes it once to 200. Callgrind went down from 21,840,123 to 21,812,126. Even a script that adds two arrays with just 3 items (i.e. no realloc needed) decreases in operations.