### PR TITLE
Allow StringView to be concatenated to String and as argument in String::format

### DIFF
--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -377,23 +377,6 @@ public:
     }
 
     /**
-     * Appends two Strings together and returns the result.
-     *
-     * ```
-     * auto str1 = String { "foo" };
-     * auto str2 = String { "bar" };
-     * assert_str_eq("foobar", str1 + str2);
-     *
-     * assert_str_eq("12", String("1") + "2");
-     * ```
-     */
-    String operator+(const String &other) const {
-        auto new_string = String(*this);
-        new_string.append(other);
-        return new_string;
-    }
-
-    /**
      * Replaces the String data by copying from an a C string.
      *
      * ```
@@ -409,6 +392,23 @@ public:
         }
         set_str(other);
         return *this;
+    }
+
+    /**
+     * Appends two Strings together and returns the result.
+     *
+     * ```
+     * auto str1 = String { "foo" };
+     * auto str2 = String { "bar" };
+     * assert_str_eq("foobar", str1 + str2);
+     *
+     * assert_str_eq("12", String("1") + "2");
+     * ```
+     */
+    String operator+(const String &other) const {
+        auto new_string = String(*this);
+        new_string.append(other);
+        return new_string;
     }
 
     /**
@@ -1898,4 +1898,5 @@ protected:
     size_t m_length { 0 };
     size_t m_capacity { 0 };
 };
+
 }

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -405,7 +405,8 @@ public:
      * assert_str_eq("12", String("1") + "2");
      * ```
      */
-    String operator+(const String &other) const {
+    template <class T>
+    String operator+(const T &other) const {
         auto new_string = String(*this);
         new_string.append(other);
         return new_string;
@@ -421,9 +422,14 @@ public:
      * str1 += str2;
      *
      * assert_str_eq("foobar", str1);
+     *
+     * auto str3 = String { "1" };
+     * str3 += "2";
+     * assert_str_eq("12", str3);
      * ```
      */
-    String &operator+=(const String &other) {
+    template <class T>
+    String &operator+=(const T &other) {
         append(other);
         return *this;
     }

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -412,6 +412,23 @@ public:
     }
 
     /**
+     * Appends a second string to the first string, modifying the first
+     * string in place.
+     *
+     * ```
+     * auto str1 = String { "foo" };
+     * auto str2 = String { "bar" };
+     * str1 += str2;
+     *
+     * assert_str_eq("foobar", str1);
+     * ```
+     */
+    String &operator+=(const String &other) {
+        append(other);
+        return *this;
+    }
+
+    /**
      * Returns the character at the specified index.
      *
      * ```

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -1546,7 +1546,7 @@ public:
     static void format(String &out, const char *fmt, T first, Args... rest) {
         for (const char *c = fmt; *c != 0; c++) {
             if (*c == '{' && *(c + 1) == '}') {
-                out.append(first);
+                out += first;
                 format(out, c + 2, rest...);
                 return;
             } else {

--- a/include/tm/string_view.hpp
+++ b/include/tm/string_view.hpp
@@ -316,7 +316,7 @@ public:
     }
 
     /**
-     * Retruns true if the StringView has a length of zero.
+     * Returns true if the StringView has a length of zero.
      *
      * ```
      * auto str = String("abc");

--- a/include/tm/string_view.hpp
+++ b/include/tm/string_view.hpp
@@ -334,4 +334,38 @@ private:
     size_t m_length { 0 };
 };
 
+/**
+ * Concatenate a StringView to a String without having to convert to
+ * StringView to a String first.
+ * ```
+ * const auto str1 = String { "abc" };
+ * const auto str2 = String { "cdefg" };
+ * const auto sv = StringView { &str2, 1, 3 };
+ *
+ * assert_str_eq("abcdef", str1 + sv);
+ * assert_str_eq("abc", str1);
+ * ```
+ */
+inline String operator+(const String &lhs, const StringView &rhs) {
+    auto res = lhs.clone();
+    res.append(rhs.dangerous_pointer_to_underlying_data(), rhs.size());
+    return res;
+}
+
+/**
+ * Append a StringView to a String without having to create a new String first
+ * ```
+ * auto str1 = String { "abc" };
+ * const auto str2 = String { "cdefg" };
+ * const auto sv = StringView { &str2, 1, 3 };
+ * str1 += sv;
+ *
+ * assert_str_eq("abcdef", str1);
+ * ```
+ */
+inline String &operator+=(String &lhs, const StringView &rhs) {
+    lhs.append(rhs.dangerous_pointer_to_underlying_data(), rhs.size());
+    return lhs;
+}
+
 }


### PR DESCRIPTION
We sometimes have Natalie code like this:
```c++
env->raise("ArgumentError", "invalid range \"{}-{}\" in string transliteration", last_character.to_string(), next_value.to_string());
```
With `last_character` and `next_value` being string views.

This is the string equivalent of the integer hydration: we have all the information we need available in the view, but we still create a new String object (including a heap allocation for the chars), only to concatenate those chars we already knew.

This change allows string views to be used as arguments in format in in concatenation (when the lhs is a string), without having to convert them to Strings first.